### PR TITLE
投稿に対するいいね機能実装

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,2 @@
+class LikesController < ApplicationController
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,2 +1,3 @@
 class LikesController < ApplicationController
+
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,5 +1,4 @@
 class LikesController < ApplicationController
-
   def create
     @post = Post.find(params[:post_id])
     current_user.like(@post)
@@ -12,5 +11,4 @@ class LikesController < ApplicationController
     current_user.unlike(@post)
     # userモデルで設定したunlikeメソッドを実行している。
   end
-
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,3 +1,16 @@
 class LikesController < ApplicationController
 
+  def create
+    @post = Post.find(params[:post_id])
+    current_user.like(@post)
+    # userモデルで設定したlikeメソッド。(モデルにpost_idを渡すために1行目で@postを取得している)
+  end
+
+  def destroy
+    @post = Like.find(params[:id]).post
+    # 外そうとしている"いいね"のIDを取得し、そのlike_idに紐づくpostをを@postに格納
+    current_user.unlike(@post)
+    # userモデルで設定したunlikeメソッドを実行している。
+  end
+
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -10,8 +10,9 @@
 #
 # Indexes
 #
-#  index_likes_on_post_id  (post_id)
-#  index_likes_on_user_id  (user_id)
+#  index_likes_on_post_id              (post_id)
+#  index_likes_on_user_id              (user_id)
+#  index_likes_on_user_id_and_post_id  (user_id,post_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  post_id    :bigint
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_likes_on_post_id  (post_id)
+#  index_likes_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (post_id => posts.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :post

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -21,4 +21,13 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :post
+  # 一つのいいねには、必ず一人のユーザーと一つの投稿が紐づく
+
+  validates :user_id, uniqueness: { scope: :post_id }
+  # この記述でpost_idとuser_idの組をuniqueにした。１通りのみ許可のバリデーション。
+  # uniquenessはRails Validationヘルパーの一つ。
+  # 属性の値が一意（unique）であり重複していないことを検証する。
+  # 属性について同じ値のレコードがモデルにあるかをクエリを走らせ確認する。
+  # scopeオプションは他のカラムに一意性制約を求めることが出来る。
+  # 今回のケースだと、ひとつの":user_id"シンボルに紐づくscope先の"post_id"カラムのレコードに対しuniquenessを実行している。
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -34,6 +34,11 @@ class Post < ApplicationRecord
   # postは複数のcommentを持つ
   # dependent: :destroyについてはuserモデルに記述済
 
+  has_many :likes, dependent: :destroy
+  # ↓いいねをしたuserを取得するための記述
+  has_many :like_users, through: :likes, source: :user
+  # 記述意図はuser.rbと重複するので割愛
+
   validates :body, presence: true, length: { maximum: 255 }
   validates :images, presence: true
   # migrationファイルでnullfalseをつけたものはこちらでもバリデーションをつける。

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
 
   def like?(post)
     like_posts.include?(post)
-    # current_userが持つ"like_posts"にコントローラーより受け取った"postオブジェクト"が格納されているかどうかを確認する。
+    # current_userが持つ"like_posts"にview(_like_area)より受け取った"postオブジェクト"が格納されているかどうかを確認する。
     # 配列current_userが、postと等しい要素を持つ時にtrue、持たない時にfalseを返す。
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,19 @@ class User < ApplicationRecord
   # userは、複数のpost/複数のcommentを持つ
   # dependent: :destroyを設定することで、userを削除したときアソシエーション先（この場合はpost・comment）にもdestroyアクションを実行することができる（削除できる）
 
+  has_many :likes, dependent: :destroy
+  # ↓いいねをしたpostを取得するための記述
+  has_many :like_posts, through: :likes, source: :post
+  # throughオプションは指定したテーブルを経由して関連先のデータを取得できるようになるオプション。
+  # "has_many :like_posts, through: :likes"のままではlikesテーブルを経由した後の参照先が不明。(like_postsはテーブル名ではなく独自に設定したメソッド名のようなもの？)
+  # sourceオプションにより参照先のテーブルを明示することができる。
+  # 'source: :post'としてあげれば、likesテーブルを経由しpostsテーブルのデータを取得してくることができる。
+
+  # 〜〜なぜわざわざsourceオプションを使ってまでlike_postsという項目を作っているのか考察〜〜
+  # 「userがいいねしたpostを取得したい」ということであれば、"has_many :posts, through: :likes"でも良いように一見考えられるが、
+  # userとpostの間には既にアソシエーションが組まれており、そこに新たな関係性を追加することはできないためlike_postsという項目を設定する必要がある。
+
+
   validates :username, uniqueness: true, presence: true
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,22 @@ class User < ApplicationRecord
   # 「userがいいねしたpostを取得したい」ということであれば、"has_many :posts, through: :likes"でも良いように一見考えられるが、
   # userとpostの間には既にアソシエーションが組まれており、そこに新たな関係性を追加することはできないためlike_postsという項目を設定する必要がある。
 
+  def like(post)
+    like_posts << post
+    # current_userが持つ"like_posts"を配列形式とし、コントローラーより受け取った"postオブジェクト(いいねしようとしている投稿)"を
+    # いいねするたびに格納していくという処理。
+  end
+
+  def unlike(post)
+    like_posts.destroy(post)
+    # current_userが持つ"like_posts"に格納されているpost(コントローラーから受け取ったpost)を削除する。
+  end
+
+  def like?(post)
+    like_posts.include?(post)
+    # current_userが持つ"like_posts"にコントローラーより受け取った"postオブジェクト"が格納されているかどうかを確認する。
+    # 配列current_userが、postと等しい要素を持つ時にtrue、持たない時にfalseを返す。
+  end
 
   validates :username, uniqueness: true, presence: true
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/likes/create.js.slim
+++ b/app/views/likes/create.js.slim
@@ -1,0 +1,3 @@
+| $('#like_area-#{@post.id}').html("#{j render('posts/unlike', post: @post)}")
+/ create(いいね)が実行されたら、いいねを外すためのリンクに差し替える
+/ posts/_like_area の分岐を切り替えているイメージ

--- a/app/views/likes/destroy.js.slim
+++ b/app/views/likes/destroy.js.slim
@@ -1,0 +1,3 @@
+| $('#like_area-#{@post.id}').html("#{j render('posts/like', post: @post)}")
+/ destory(いいねを外す)が実行されたら、いいねをするためのリンクに差し替える
+/ posts/_like_area の分岐を切り替えているイメージ

--- a/app/views/posts/_like.html.slim
+++ b/app/views/posts/_like.html.slim
@@ -1,0 +1,9 @@
+= link_to likes_path(post_id: post.id), method: :post, remote: true do
+  = icon 'far', 'heart', class: 'fa-lg'
+
+/ like_areaにていいねされていないの投稿である場合の表示。
+/ 色が塗られていないハートが表示されていて、ボタンを押すといいねをする(post)という処理をリクエストする。
+/ ※↓理解が怪しい※
+/ ルーティングでは、"likes POST   /likes(.:format)  likes#create" となっており、
+/ リンク先は単純に"link_to likes_path"のみで良いようにも思える？
+/ コントローラーに(params[:post_id])を渡せるように"link_to likes_path(post_id: post.id)"と記述しているのではないかと考えた。

--- a/app/views/posts/_like_area.html.slim
+++ b/app/views/posts/_like_area.html.slim
@@ -1,0 +1,6 @@
+div id="like_area-#{post.id}"
+  - if current_user.like?(post)
+    = render 'unlike', post: post
+  - else
+    = render 'like', post: post
+  / user.rbにて設定しているlike?メソッドを実行している。

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -12,6 +12,11 @@
           = link_to edit_post_path(post) do
             = icon 'far', 'edit', class: 'fa-lg'
 
+      / ログイン時かつ自身の投稿でない場合は"いいね"ができる分岐を導入する
+      - if logged_in? && post.user_id != current_user.id
+        .ml-auto
+          = render 'like_area', post: post
+
   = link_to post_path(post) do
     / swiperの公式ページ見本に沿って記述
     .swiper-container

--- a/app/views/posts/_unlike.html.slim
+++ b/app/views/posts/_unlike.html.slim
@@ -1,0 +1,6 @@
+= link_to like_path(current_user.likes.find_by(post_id: post.id)), method: :delete, remote: true do
+  = icon 'fa', 'heart', class: 'fa-lg'
+
+/ like_areaにていいね済みの投稿である場合の表示。
+/ 色ぬりのハートが表示されていて、ボタンを押すといいねを外す(delete)という処理をリクエストする。
+/ 受け取っている変数postの中身を元にlike_pathを割り出す(likesの中からpost_idを持つlikeを探している)

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -20,6 +20,11 @@
             = link_to edit_post_path(@post) do
               = icon 'far', 'edit', class: 'fa-lg'
 
+        / ログイン時かつ自身の投稿でない場合は"いいね"ができる分岐を導入する
+        - if logged_in? && @post.user_id != current_user.id
+          .ml-auto
+            = render 'like_area', post: @post
+
     hr.m-0
     .post-body.p-3
       / 投稿の本文

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   # comment_idをparamsに持つアクション(show/edit/update/destroy)についてURLのposts部分を省くことができる。
   # (urlを短くしても一意性を確保出来ている)
 
+  resources :likes, only: %i[create destroy]
+
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/db/migrate/20200901105533_create_likes.rb
+++ b/db/migrate/20200901105533_create_likes.rb
@@ -1,0 +1,10 @@
+class CreateLikes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :likes do |t|
+      t.references :user, foreign_key: true
+      t.references :post, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200901105533_create_likes.rb
+++ b/db/migrate/20200901105533_create_likes.rb
@@ -5,6 +5,7 @@ class CreateLikes < ActiveRecord::Migration[5.2]
       t.references :post, foreign_key: true
 
       t.timestamps
+      t.index [:user_id, :post_id], unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_065317) do
+ActiveRecord::Schema.define(version: 2020_09_01_105533) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -20,6 +20,15 @@ ActiveRecord::Schema.define(version: 2020_08_28_065317) do
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -44,5 +53,7 @@ ActiveRecord::Schema.define(version: 2020_08_28_065317) do
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2020_09_01_105533) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
投稿に対し、いいねを付与することができる機能を追加する

## 仕様
・ログインユーザーのみ、投稿に対しいいねをすることができる
・自分の投稿にはいいねできない
・ユーザは一つの投稿に対し１つのいいねしか持てない

## 実装内容
・likeモデルの追加
・likesコントローラーの追加(create、destroy)
・viewの実装(一部非同期処理)