### PR TITLE
08-ユーザーページに投稿一覧表示

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -97,3 +97,24 @@ img {
 .pagination {
   justify-content: center;
 }
+
+// _thumbnail_post.html.slimでclass設定
+.thumbs {
+  width: 100%;
+  position: relative;
+  display: block;
+
+  &::before {
+    content: "";
+    display: block;
+    padding-top: 100%;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    object-fit: cover;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ class ApplicationController < ActionController::Base
   before_action :set_search_posts_form
   add_flash_types :success, :info, :warning, :danger
 
-
   def not_authenticated
     redirect_to login_path, warning: 'ログインしてください'
     # not_authenticatedはsorceryにデフォルトで設定されているメソッド。require_loginに引っかかった時に実行される。

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,12 +9,12 @@ class PostsController < ApplicationController
     # params[:page]により現在のページパラメーターを受け取っている
     # kaminariのデフォルト設定により最初のページはparamsを無視する（config.params_on_first_page = false）
     @posts = if current_user
-              # ログイン中であれば、ログインしているユーザーがフォローしている人の投稿のみ表示される分岐
-              current_user.feed.includes(:user).page(params[:page]).order(created_at: :desc)
-              # feedはuser.rbにて設定。フォロー済ユーザー+自分のPostを取り出すメソッド。
+               # ログイン中であれば、ログインしているユーザーがフォローしている人の投稿のみ表示される分岐
+               current_user.feed.includes(:user).page(params[:page]).order(created_at: :desc)
+               # feedはuser.rbにて設定。フォロー済ユーザー+自分のPostを取り出すメソッド。
              else
-              Post.all.includes(:user).page(params[:page]).order(created_at: :desc)
-              # 非ログイン時は全ての投稿を表示。
+               Post.all.includes(:user).page(params[:page]).order(created_at: :desc)
+               # 非ログイン時は全ての投稿を表示。
              end
     @users = User.recent(5)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-  
   def index
     @users = User.all.page(params[:page]).order(created_at: :desc)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,8 +39,6 @@ class User < ApplicationRecord
   # 「userがいいねしたpostを取得したい」ということであれば、"has_many :posts, through: :likes"でも良いように一見考えられるが、
   # userとpostの間には既にアソシエーションが組まれており、そこに新たな関係性を追加することはできないためlike_postsという項目を設定する必要がある。
 
-
-
   # 【フォロー機能に関するアソシエーション】
   # userとrelationshipについてアソシエーションを組む必要がある。簡潔に"has_many :relationships"としたい所だが、
   # relationshipテーブルに２つあるカラムはどちらもuserテーブルに紐づく中間テーブルとなっており、どちらのカラムとのアソシエーションなのかをしっかり区別してあげる必要がある。
@@ -50,7 +48,7 @@ class User < ApplicationRecord
   # active_relationshipsと命名しているため、class_nameでテーブル名を明示。かつforeign_key設定により参照するカラムも指定。
   has_many :passive_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy
   # 上と同じ。
-  
+
   # ActiveRecordの関連付け。correctionを取得する。
   has_many :following, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
@@ -58,7 +56,6 @@ class User < ApplicationRecord
   # 上記で設定した"〜〜〜_relationships"を経由し、sourceを持つuserを関連付ける。
   # user.followingを実行する→→"active_relationships"を経由する(userは自身のidを元にRelationテーブル/follower_idを参照)→→sourceオプションにより、idが一致したレコードのデータを取得できる
   # 要は関連付けされたコレクションを取得できるよってこと。
-  
 
   # 【いいね機能に関するメソッド】
   # 主にhas_many関連付けをしたコレクションメソッド"like_posts"を使用する。"self"は省略されている。

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,0 +1,4 @@
+.col-md-4.mb-3
+  = link_to post_path(thisPost), class: 'thumbs' do
+    = image_tag thisPost.images.first.url
+/ users/showから@user.postsを受け取っている。

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,4 +1,4 @@
 .col-md-4.mb-3
   = link_to post_path(thisPost), class: 'thumbs' do
     = image_tag thisPost.images.first.url
-/ users/showから@user.postsを受け取っている。
+/ users/showからthisPost(user.postのこと)を受け取っている。

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,4 +1,4 @@
 .col-md-4.mb-3
-  = link_to post_path(thisPost), class: 'thumbs' do
-    = image_tag thisPost.images.first.url
-/ users/showからthisPost(user.postのこと)を受け取っている。
+  = link_to post_path(thumbnail_post), class: 'thumbs' do
+    = image_tag thumbnail_post.images.first.url
+/ users/showからthumbnail_post(user.postのこと)を受け取っている。

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -13,7 +13,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
         a.nav-link href="#"
           = icon 'far', 'heart', class: 'fa-lg'
       li.nav-item
-        a.nav-link href="#"
+        = link_to user_path(current_user), class: 'nav-link' do
           = icon 'far', 'user', class: 'fa-lg'
       li.nav-item
         = link_to 'ログアウト', logout_path, class: 'nav-link', method: :delete

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -11,9 +11,5 @@
             = render 'follow_area', user: @user
           hr
           .row
-            = render partial: 'posts/thumbnail_post', collection: @user.posts, as: "thisPost"
+            = render partial: 'posts/thumbnail_post', collection: @user.posts
             / showページが所持している@user.postsを"posts/thumbnail_post"へ渡す
-            / 〜〜見本にはない「as: "thisPost"」について〜〜
-            / collectionで@user.postsとしているので、部分テンプレート先に渡す変数名は「user.post」となると考えていた。
-            / しかし、部分テンプレート先では"thumbnail_post"が変数として使われている。(user.postだとエラーになる)
-            / どこかで「部分テンプレート名を変数名に当てるのはあまり良くない」というのを見た気がする（気のせいかも）

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,6 +1,6 @@
 .container
   .row
-    .col-md-6.offset-md-3
+    .col-md-10.offset-md-1
       .card
         .card-body
           .text-center.mb-3
@@ -9,3 +9,11 @@
             = @user.username
           .text-center
             = render 'follow_area', user: @user
+          hr
+          .row
+            = render partial: 'posts/thumbnail_post', collection: @user.posts, as: "thisPost"
+            / showページが所持している@user.postsを"posts/thumbnail_post"へ渡す
+            / 〜〜見本にはない「as: "thisPost"」について〜〜
+            / collectionで@user.postsとしているので、部分テンプレート先に渡す変数名は「user.post」となると考えていた。
+            / しかし、部分テンプレート先では"thumbnail_post"が変数として使われている。(user.postだとエラーになる)
+            / どこかで「部分テンプレート名を変数名に当てるのはあまり良くない」というのを見た気がする（気のせいかも）


### PR DESCRIPTION
## 概要
ユーザーページに投稿一覧表示機能を実装する

## 仕様
・タイル表示する
・ヘッダーのユーザーアイコンに自分のユーザー詳細ページへのリンクを設定する